### PR TITLE
feat: Add Find All Member data API

### DIFF
--- a/src/main/java/com/waffle/waffle/configure/SecurityConfig.java
+++ b/src/main/java/com/waffle/waffle/configure/SecurityConfig.java
@@ -36,8 +36,8 @@ public class SecurityConfig {
 
                 // 시큐리티 처리에 HttpServletRequest를 이용함
                 .authorizeRequests()
-                // "/index", "/login"로 시작하는 uri 요청은 별도의 인증 절차 없이 허용
-                .antMatchers("/index", "/login").permitAll()
+                // "/main"으로 시작하는 uri 요청은 별도의 인증 절차 없이 허용
+                .antMatchers("/main").permitAll()
                 // "/member"로 시작하는 uri 요청은 인증 완료 후 [MEMBER, ADMIN] 이 중 하나 이상의 권한을 가진 사용자만 접근 허용
                 .antMatchers("/member").hasAnyRole("MEMBER", "ADMIN")
                 // "/admin" uri 요청은 인증 완료 후 [ADMIN] 권한을 가진 사용자만 접근 허용

--- a/src/main/java/com/waffle/waffle/controller/AdminController.java
+++ b/src/main/java/com/waffle/waffle/controller/AdminController.java
@@ -1,6 +1,9 @@
 package com.waffle.waffle.controller;
 
 import com.waffle.waffle.domain.DTO.FineDTO;
+import com.waffle.waffle.domain.DTO.MemberDTO;
+import com.waffle.waffle.domain.Member;
+import com.waffle.waffle.repository.MemberRepository;
 import com.waffle.waffle.service.FineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,18 +11,30 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class FineController {
+public class AdminController {
+    private final MemberRepository memberRepository;
 
     private final FineService fineService;
 
-    // 관리자 전용 페이지
+    // 관리자 전용 페이지, 모든 멤버의 이름과 파트가 보임
     @GetMapping("/admin")
-    public ResponseEntity<String> admin() {
-        return ResponseEntity.ok("관리자 페이지");
+    public ResponseEntity<List<MemberDTO>> admin() {
+        List<Member> list = memberRepository.findAll();
+        return ResponseEntity.ok(list.stream()
+                .map(Member::toDTO)
+                .collect(Collectors.toList()));
+    }
+
+    // 관리자가 특정 멤버의 내역을 확인
+    @GetMapping("/admin/{memberId}")
+    public ResponseEntity<List<FineDTO>> findByMemberId(@PathVariable("memberId") String memberId) {
+        List<FineDTO> list = fineService.findByMemberId(memberId);
+        return ResponseEntity.ok(list);
     }
 
     // 관리자 페이지에서 벌금 추가하기 RequestBody -> memberId(String), date(YYYY-MM-DD), type(00, 01, 10)
@@ -29,22 +44,8 @@ public class FineController {
         return ResponseEntity.ok("add fine successfully");
     }
 
-    // 테스트용, 관리자 페이지에서 전체 벌금 내역을 문자열로 출력
-    @GetMapping("/admin/list")
-    public ResponseEntity<List<FineDTO>> adminList() {
-        List<FineDTO> list = fineService.findAll();
-        return ResponseEntity.ok(list);
-    }
-
-    // 관리자가 특정 멤버의 내역을 확인
-    @GetMapping("/admin/{memberId}/list")
-    public ResponseEntity<List<FineDTO>> findByMemberId(@PathVariable("memberId") String memberId) {
-        List<FineDTO> list = fineService.findByMemberId(memberId);
-        return ResponseEntity.ok(list);
-    }
-
     // 멤버의 내역 중 선택한 내역의 상태를 변경 (납부/미납)
-    @PatchMapping("/admin/{memberId}/list")
+    @PatchMapping("/admin/{memberId}")
     public ResponseEntity<String> payFine(@PathVariable("memberId") String memberId, @RequestBody FineDTO fineRequestDto) {
         if(fineRequestDto == null) {
             return ResponseEntity.ok("bad request");
@@ -56,7 +57,7 @@ public class FineController {
     }
 
     // 멤버의 내역 중 선택한 내역을 삭제
-    @DeleteMapping("/admin/{memberId}/list")
+    @DeleteMapping("/admin/{memberId}")
     public ResponseEntity<String> deleteFine(@PathVariable("memberId") String memberId, @RequestBody FineDTO fineRequestDto) {
         if(fineRequestDto == null) {
             return ResponseEntity.ok("bad request");
@@ -67,4 +68,10 @@ public class FineController {
         }
     }
 
+    // 테스트용, 관리자 페이지에서 전체 벌금 내역을 문자열로 출력, 테스트용
+    @GetMapping("/admin/list")
+    public ResponseEntity<List<FineDTO>> adminList() {
+        List<FineDTO> list = fineService.findAll();
+        return ResponseEntity.ok(list);
+    }
 }

--- a/src/main/java/com/waffle/waffle/controller/MemberController.java
+++ b/src/main/java/com/waffle/waffle/controller/MemberController.java
@@ -20,20 +20,20 @@ import java.security.Principal;
 public class MemberController {
     private final MemberService memberService;
 
+    // 메인 페이지
+    @GetMapping("/main")
+    public ResponseEntity<String> main() {
+        return ResponseEntity.ok("메인 로그인 페이지");
+    }
+
     // 로그인, id와 pw가 저장된 request body를 자바 객체로 변환하고 로그인 과정에 사용
-    @PostMapping("/login")
+    @PostMapping("/main")
     // @RequestBody: HTTP Request Body 내용을 통째로 자바 객체로 변환해서 매핑된 메소드 파라미터로 전달
     public TokenDTO login(@RequestBody LoginDTO memberLoginRequestDto) {
         String memberId = memberLoginRequestDto.getMemberId();
         String password = memberLoginRequestDto.getPassword();
         TokenDTO tokenDTO = memberService.login(memberId, password);
         return tokenDTO;
-    }
-
-    // 메인 페이지
-    @GetMapping("/index")
-    public ResponseEntity<String> index() {
-        return ResponseEntity.ok("메인 페이지");
     }
 
     // 멤버 전용 페이지


### PR DESCRIPTION
Add Find All Member data API

/main  (GetMapping) : 메인 페이지 로그인 창 보임
/main  (PostMapping) : 폼에 id, pw 입력하고 로그인 시도
필요 : json 형태로 "memberId"값, "password"값

------------------------------------------------------------------------------------------------------------------------------------------------------

/member  (GetMapping) : 현재 로그인 정보로 멤버의 정보를 가져와서 보여줌
필요 : 인증 토큰(로그인 한 상태)

------------------------------------------------------------------------------------------------------------------------------------------------------
(admin uri는 관리자만 입장 가능)

/admin  (GetMapping) : 전체 멤버의 이름과 파트를 가져와서 보여줌
필요 : 인증 토큰(로그인 한 상태)

/admin/{memberId} (GetMapping) : 위에서 이름을 눌렀을 때 디테일 페이지, 벌금 추가할 수 있는 페이지 ( 날짜, 유형 선택 )
필요 : 인증 토큰(로그인 한 상태)

/admin/{memberId} (PostMapping) : 폼에 날짜, 유형 선택하고 추가 버튼 눌렀을 때, 실제 DB에 저장
필요 : 인증 토큰(로그인 한 상태), json 형태로 "memberId"값, "date"값, "type"값 
                                                       (순서대로 아이디, 날짜 YYYY-MM-DD, 벌금 유형 00: 지각, 01: 결석, 10: 미제출)

/admin/{memberId} (PatchMapping) : 내역(fine)의 id가 필요함, 벌금 내역 중에서 납부 버튼을 누르는 경우 그 내역의 status가 toggle
필요 : 인증 토큰(로그인 한 상태), 선택하려는 내역의 id

/admin/{memberId} (DeleteMapping) : 내역(fine)의 id가 필요함, 벌금 내역 삭제
필요 : 인증 토큰(로그인 한 상태), 선택하려는 내역의 id
